### PR TITLE
Fix a compiler error on Windows with Chromium 75.

### DIFF
--- a/test/usermodel_unittest.cc
+++ b/test/usermodel_unittest.cc
@@ -51,7 +51,7 @@ class UserModelTest : public ::testing::Test {
     base::FilePath path(kTestDataRelativePath);
     path = path.AppendASCII(filename);
 
-    std::ifstream ifs(path.value());
+    std::ifstream ifs(path.value().c_str());
     if (ifs.fail()) {
       return "";
     }


### PR DESCRIPTION
Fix unit test build on Windows.
std::ifstream constructor on Windows cannot have std::wstring passed in.

Fixes #9 

Likely due to Chromium change:

    commit ff480e1803a097f5485fbee9833edb04e96676e0
    Author: Tom Anderson <thomasanderson@chromium.org>
    Date:   Mon Apr 29 17:31:15 2019 +0000

        [Merge to M75] Reenable libc++ on Windows

        > BUG=801780
        > R=thakis
        >
        > Change-Id: Ife6f11c4e02534c879731274d427b0f563b8fa08
        > Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/1556590
        > Auto-Submit: Thomas Anderson <thomasanderson@chromium.org>
        > Commit-Queue: Nico Weber <thakis@chromium.org>
        > Reviewed-by: Nico Weber <thakis@chromium.org>
        > Cr-Commit-Position: refs/heads/master@{#652740}

        BUG=801780