### PR TITLE
Fix unit test compiler error with GetWinningCategory

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,12 +104,12 @@ containing the pages HTML content, a vector of scores is returned as follows:
 std::vector<double> scores = ClassifyPage(html);
 ```
 
-Get the winning category by calling `WinningCategory(scores)` where `scores` is
-a `std::vector<double>` of immediate or over time winning scores, the winning
-category is returned as follows:
+Get the winning category by calling `GetWinningCategory(scores)` where
+`scores` is a `std::vector<double>` of immediate or over time winning
+scores, the winning category is returned as follows:
 
 ```
-std::string winning_category = WinningCategory(scores);
+std::string winning_category = GetWinningCategory(scores);
 ```
 
 ## Unit Tests

--- a/test/usermodel_unittest.cc
+++ b/test/usermodel_unittest.cc
@@ -117,7 +117,7 @@ TEST_F(UserModelTest, ClassifierTest) {
 
     auto html = LoadFile(doc);
     auto scores = user_model.ClassifyPage(html);
-    auto predicted = user_model.WinningCategory(scores);
+    auto predicted = user_model.GetWinningCategory(scores);
 
     if (predicted != label) {
       std::cout << "FAILED 3" << std::endl;
@@ -164,7 +164,7 @@ TEST_F(UserModelTest, InvalidWordCountClassifierTest) {
 
     auto html = LoadFile(doc);
     auto scores = user_model.ClassifyPage(html);
-    auto predicted = user_model.WinningCategory(scores);
+    auto predicted = user_model.GetWinningCategory(scores);
 
     if (predicted != label) {
       std::cout << "FAILED 3" << std::endl;


### PR DESCRIPTION
Method was renamed, but it looks like the unit tests weren't updated. Also fixed the README.